### PR TITLE
Add the "type" URL parameter to the request in sendUpdateValueNgsi2 function

### DIFF
--- a/lib/services/ngsi/ngsiService.js
+++ b/lib/services/ngsi/ngsiService.js
@@ -428,7 +428,7 @@ function sendUpdateValueNgsi2(entityName, attributes, typeInformation, token, ca
     var payload = {};
 
     var options = createRequestObject(
-        '/v2/entities/' + entityName + '/attrs',
+        '/v2/entities/' + entityName + '/attrs' + '?type=' + typeInformation.type,
         typeInformation,
         token);
 


### PR DESCRIPTION
Add the URL parameter "type" to specify the type in case of ambiguity when there are several entities with the same "id" but different types as described in the issue #733